### PR TITLE
General code quality fix-3

### DIFF
--- a/FileManager/src/org/openintents/filemanager/compatibility/BookmarkListActionHandler.java
+++ b/FileManager/src/org/openintents/filemanager/compatibility/BookmarkListActionHandler.java
@@ -37,7 +37,7 @@ public class BookmarkListActionHandler {
 			// Handle selection
 			switch (item.getItemId()) {
 			case R.id.menu_delete:
-				list.getContext().getContentResolver().delete(BookmarksProvider.CONTENT_URI, BookmarksProvider._ID + "=?", new String[] {""+id});
+				list.getContext().getContentResolver().delete(BookmarksProvider.CONTENT_URI, BookmarksProvider._ID + "=?", new String[] {Long.toString(id)});
 				break;
 			}
 			// Multiple selection
@@ -46,7 +46,7 @@ public class BookmarkListActionHandler {
 			case R.id.menu_delete:
 				long[] ids = ListViewMethodHelper.listView_getCheckedItemIds(list);
 				for(int i=0; i<ids.length; i++){
-					list.getContext().getContentResolver().delete(BookmarksProvider.CONTENT_URI, BookmarksProvider._ID + "=?", new String[] {""+ids[i]});
+					list.getContext().getContentResolver().delete(BookmarksProvider.CONTENT_URI, BookmarksProvider._ID + "=?", new String[] {Long.toString(ids[i])});
 				}
 				break;
 			}

--- a/FileManager/src/org/openintents/filemanager/util/FileUtils.java
+++ b/FileManager/src/org/openintents/filemanager/util/FileUtils.java
@@ -126,14 +126,10 @@ public class FileUtils {
 	 * @return
 	 */
 	public static boolean isMediaUri(String uri) {
-		if (uri.startsWith(Audio.Media.INTERNAL_CONTENT_URI.toString())
+		return uri.startsWith(Audio.Media.INTERNAL_CONTENT_URI.toString())
 				|| uri.startsWith(Audio.Media.EXTERNAL_CONTENT_URI.toString())
 				|| uri.startsWith(Video.Media.INTERNAL_CONTENT_URI.toString())
-				|| uri.startsWith(Video.Media.EXTERNAL_CONTENT_URI.toString())) {
-			return true;
-		} else {
-			return false;
-		}
+				|| uri.startsWith(Video.Media.EXTERNAL_CONTENT_URI.toString());
 	}
 	
 	/**

--- a/FileManager/src/org/openintents/filemanager/view/PathBar.java
+++ b/FileManager/src/org/openintents/filemanager/view/PathBar.java
@@ -418,11 +418,7 @@ public class PathBar extends ViewFlipper {
 		} else if (dirTreeDepth < initTreeDepth) {
 			return true;
 		} else {
-			if (dirPath.equals(mInitialDirectory.getAbsolutePath())) {
-				return true;
-			} else {
-				return false;
-			}
+			return dirPath.equals(mInitialDirectory.getAbsolutePath());
 		}
 	}
 	

--- a/FileManagerDemo/src/org/openintents/filemanager/demo/Demo.java
+++ b/FileManagerDemo/src/org/openintents/filemanager/demo/Demo.java
@@ -235,7 +235,7 @@ public class Demo extends Activity {
 				if (filePath != null) {
 					mEditText.setText(filePath);
 					String strFileSize = getString(R.string.get_content_info,
-							displayName, "" + fileSize);
+							displayName, Long.toString(fileSize));
 					mTextView.setText(strFileSize);
 				}
 			}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2131- Primitives should not be boxed just for "String" conversion.
squid:S1126 - Return of boolean expressions should not be wrapped into an "if-then-else" statement. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:S1126

Please let me know if you have any questions.

Faisal Hameed