### PR TITLE
General code quality fix-4

### DIFF
--- a/FileManager/src/org/openintents/filemanager/FileManagerProvider.java
+++ b/FileManager/src/org/openintents/filemanager/FileManagerProvider.java
@@ -151,8 +151,7 @@ public class FileManagerProvider extends ContentProvider {
 			if (mode.equalsIgnoreCase("rw"))
 				m = ParcelFileDescriptor.MODE_READ_WRITE;
 			File f = new File(uri.getPath());
-			ParcelFileDescriptor pfd = ParcelFileDescriptor.open(f, m);
-			return pfd;
+			return ParcelFileDescriptor.open(f, m);
 		} else {
 			throw new FileNotFoundException	("Unsupported uri: " + uri.toString());
 		}

--- a/FileManager/src/org/openintents/filemanager/util/FileUtils.java
+++ b/FileManager/src/org/openintents/filemanager/util/FileUtils.java
@@ -197,12 +197,10 @@ public class FileUtils {
 	 */
 	public static File getFile(String curdir, String file) {
 		String separator = "/";
-		  if (curdir.endsWith("/")) {
-			  separator = "";
-		  }
-		   File clickedFile = new File(curdir + separator
-		                       + file);
-		return clickedFile;
+		if (curdir.endsWith("/")) {
+			separator = "";
+		}
+		return new File(curdir + separator + file);
 	}
 	
 	public static File getFile(File curdir, String file) {
@@ -283,8 +281,7 @@ public class FileUtils {
 			// File.canExecute() was introduced in API 9.  If it doesn't exist, then
 			// this will throw an exception and the NDK version will be used.
 			Method m = File.class.getMethod("canExecute", new Class[] {} );
-			Boolean result=(Boolean)m.invoke(mContextFile);
-			return result;
+			return (Boolean)m.invoke(mContextFile);
 		} catch (Exception e) {
 			if(libLoadSuccess){
 				return access(mContextFile.getPath(), X_OK);

--- a/FileManager/src/org/openintents/filemanager/util/MimeTypeParser.java
+++ b/FileManager/src/org/openintents/filemanager/util/MimeTypeParser.java
@@ -55,7 +55,7 @@ public class MimeTypeParser {
 		XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
 
 		mXpp = factory.newPullParser();
-		mXpp.setInput(new InputStreamReader(in));
+		mXpp.setInput(new InputStreamReader(in, "UTF-8"));
 
 		return parse();
 	}

--- a/FileManagerTest/src/org/openintents/filemanager/test/TestFileManagerActivity.java
+++ b/FileManagerTest/src/org/openintents/filemanager/test/TestFileManagerActivity.java
@@ -14,8 +14,10 @@
 package org.openintents.filemanager.test;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.util.Random;
 
 import android.app.Activity;
@@ -122,7 +124,7 @@ public class TestFileManagerActivity extends InstrumentationTestCase {
 
 	private void createFile(String path, String content) throws IOException {
 		File file = new File(path);
-		FileWriter wr = new FileWriter(file);
+		OutputStreamWriter wr = new OutputStreamWriter(new FileOutputStream(file), "UTF-8");
 		wr.write(content);
 		wr.close();
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S1943 - Classes and methods that rely on the default system encoding should not be used.  
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S1943

Please let me know if you have any questions.
 
Faisal Hameed