### PR TITLE
Code quality fix - Multiline blocks should be enclosed in curly braces.

### DIFF
--- a/FileManager/src/org/openintents/filemanager/dialogs/MultiDeleteDialog.java
+++ b/FileManager/src/org/openintents/filemanager/dialogs/MultiDeleteDialog.java
@@ -67,7 +67,7 @@ public class MultiDeleteDialog extends DialogFragment {
 		 */
 		private void recursiveDelete(File file) {
 			File[] files = file.listFiles();
-			if (files != null && files.length != 0) 
+			if (files != null && files.length != 0) {
 				// If it's a directory delete all children.
 				for (File childFile : files) {
 					if (childFile.isDirectory()) {
@@ -78,10 +78,10 @@ public class MultiDeleteDialog extends DialogFragment {
 						MediaScannerUtils.informFileDeleted(mContext, childFile);
 					}
 				}
-				
-				// And then delete parent. -- or just delete the file.
-				mResult *= file.delete() ? 1 : 0;
-				MediaScannerUtils.informFileDeleted(mContext, file);
+			}
+			// And then delete parent. -- or just delete the file.
+			mResult *= file.delete() ? 1 : 0;
+			MediaScannerUtils.informFileDeleted(mContext, file);
 		}
 		
 		@Override

--- a/FileManager/src/org/openintents/filemanager/dialogs/SingleDeleteDialog.java
+++ b/FileManager/src/org/openintents/filemanager/dialogs/SingleDeleteDialog.java
@@ -58,7 +58,7 @@ public class SingleDeleteDialog extends DialogFragment {
 		 */
 		private void recursiveDelete(File file) {
 			File[] files = file.listFiles();
-			if (files != null && files.length != 0) 
+			if (files != null && files.length != 0) {
 				// If it's a directory delete all children.
 				for (File childFile : files) {
 					if (childFile.isDirectory()) {
@@ -67,9 +67,9 @@ public class SingleDeleteDialog extends DialogFragment {
 						mResult *= childFile.delete() ? 1 : 0;
 					}
 				}
-				
-				// And then delete parent. -- or just delete the file.
-				mResult *= file.delete() ? 1 : 0;
+			}
+			// And then delete parent. -- or just delete the file.
+			mResult *= file.delete() ? 1 : 0;
 		}
 		
 		@Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2681 - Multiline blocks should be enclosed in curly braces. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2681

Please let me know if you have any questions.

Faisal Hameed