### PR TITLE
Code quality fix - Literal boolean values should not be used in condition expressions.

### DIFF
--- a/FileManager/src/org/openintents/filemanager/util/CompressManager.java
+++ b/FileManager/src/org/openintents/filemanager/util/CompressManager.java
@@ -81,7 +81,7 @@ public class CompressManager {
 
 				@Override
 				public void onDismiss(DialogInterface progressDialog) {
-					if (cancelCompression == false) {
+					if (!cancelCompression) {
 						Log.e(TAG, "Dialog Dismissed");
 						Log.e(TAG, "Compression Cancel Attempted");
 						cancelCompression = true;
@@ -103,11 +103,11 @@ public class CompressManager {
 				in.close();
 				return;
 			}
-			if (file.list() == null || cancelCompression == true) {
+			if (file.list() == null || cancelCompression) {
 				return;
 			}
 			for (String fileName : file.list()) {
-				if (cancelCompression == true) {
+				if (cancelCompression) {
 					return;
 				}
 				File f = new File(file.getAbsolutePath() + File.separator
@@ -160,7 +160,7 @@ public class CompressManager {
 			}
 			List<FileHolder> list = params[0];
 			for (FileHolder file : list) {
-				if (cancelCompression == true) {
+				if (cancelCompression) {
 					return ERROR;
 				}
 				try {

--- a/FileManager/src/org/openintents/filemanager/view/MenuBuilder.java
+++ b/FileManager/src/org/openintents/filemanager/view/MenuBuilder.java
@@ -637,7 +637,7 @@ public class MenuBuilder implements Menu {
      */
     private void onItemsChanged(boolean cleared) {
         if (!mPreventDispatchingItemsChanged) {
-            if (mIsVisibleItemsStale == false) mIsVisibleItemsStale = true;
+            if (!mIsVisibleItemsStale) mIsVisibleItemsStale = true;
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1125 - Literal boolean values should not be used in condition expressions. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1125

Please let me know if you have any questions.

Faisal Hameed