### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/FileManager/src/org/openintents/filemanager/compatibility/BitmapDrawable_Compatible.java
+++ b/FileManager/src/org/openintents/filemanager/compatibility/BitmapDrawable_Compatible.java
@@ -7,7 +7,10 @@ import android.graphics.drawable.BitmapDrawable;
 public class BitmapDrawable_Compatible {
 	
 	private static boolean use_SDK_1_6 = true;
-	
+
+	private BitmapDrawable_Compatible() {
+	}
+
 	/**
 	 * Replaces "new BitmapDrawable(context.getResources(), bitmap)" available only in SDK 1.6 and higher.
 	 * 

--- a/FileManager/src/org/openintents/filemanager/compatibility/BitmapDrawable_SDK_1_6.java
+++ b/FileManager/src/org/openintents/filemanager/compatibility/BitmapDrawable_SDK_1_6.java
@@ -6,6 +6,9 @@ import android.graphics.drawable.BitmapDrawable;
 
 public class BitmapDrawable_SDK_1_6 {
 
+	private BitmapDrawable_SDK_1_6() {
+	}
+
 	public static BitmapDrawable getNewBitmapDrawable(Resources resources, Bitmap bitmap) {
 		return new BitmapDrawable(resources, bitmap);
 	}

--- a/FileManager/src/org/openintents/filemanager/compatibility/BookmarkListActionHandler.java
+++ b/FileManager/src/org/openintents/filemanager/compatibility/BookmarkListActionHandler.java
@@ -11,6 +11,9 @@ import android.widget.ListView;
 import android.widget.AdapterView.AdapterContextMenuInfo;
 
 public class BookmarkListActionHandler {
+	private BookmarkListActionHandler() {
+	}
+
 	/**
 	 * Offers a centralized bookmark action execution component.
 	 * 

--- a/FileManager/src/org/openintents/filemanager/compatibility/BookmarkMultiChoiceModeHelper.java
+++ b/FileManager/src/org/openintents/filemanager/compatibility/BookmarkMultiChoiceModeHelper.java
@@ -10,6 +10,9 @@ import android.widget.ListView;
 
 public class BookmarkMultiChoiceModeHelper {
 
+	private BookmarkMultiChoiceModeHelper() {
+	}
+
 	public static void listView_setMultiChoiceModeListener(final ListView list, final Context context) {
 		list.setMultiChoiceModeListener(new MultiChoiceModeListener() {
 

--- a/FileManager/src/org/openintents/filemanager/compatibility/HomeIconHelper.java
+++ b/FileManager/src/org/openintents/filemanager/compatibility/HomeIconHelper.java
@@ -6,6 +6,9 @@ import android.app.Activity;
 import android.content.Intent;
 
 public class HomeIconHelper {
+	private HomeIconHelper() {
+	}
+
 	public static void activity_actionbar_setHomeButtonEnabled(Activity act){
 		act.getActionBar().setHomeButtonEnabled(true);
 	}

--- a/FileManager/src/org/openintents/filemanager/compatibility/ListViewMethodHelper.java
+++ b/FileManager/src/org/openintents/filemanager/compatibility/ListViewMethodHelper.java
@@ -7,6 +7,9 @@ import android.widget.ListView;
  * @author George Venios
  */
 public class ListViewMethodHelper {
+	private ListViewMethodHelper() {
+	}
+
 	public static long[] listView_getCheckedItemIds(ListView l){
 		return l.getCheckedItemIds();
 	}

--- a/FileManager/src/org/openintents/filemanager/files/DirectoryScanner.java
+++ b/FileManager/src/org/openintents/filemanager/files/DirectoryScanner.java
@@ -224,8 +224,11 @@ class Comparators{
 	public static final int SIZE = 2;
 	public static final int LAST_MODIFIED = 3;
 	public static final int EXTENSION = 4;
-	
-	
+
+	private Comparators() {
+	}
+
+
 	public static Comparator<FileHolder> getForFile(int comparator, boolean ascending){
 		switch(comparator){
 		case NAME: return new NameComparator(ascending);

--- a/FileManager/src/org/openintents/filemanager/util/FileUtils.java
+++ b/FileManager/src/org/openintents/filemanager/util/FileUtils.java
@@ -70,6 +70,9 @@ public class FileUtils {
      */
     private static int fileCount = 0;
 
+	private FileUtils() {
+	}
+
 	/**
 	 * Whether the filename is a video file.
 	 * 

--- a/FileManager/src/org/openintents/filemanager/util/ImageUtils.java
+++ b/FileManager/src/org/openintents/filemanager/util/ImageUtils.java
@@ -8,6 +8,9 @@ import android.graphics.drawable.Drawable;
 
 public final class ImageUtils {
 
+	private ImageUtils() {
+	}
+
 	/**
 	 * Resizes specific a Bitmap with keeping ratio.
 	 */

--- a/FileManager/src/org/openintents/intents/FileManagerIntents.java
+++ b/FileManager/src/org/openintents/intents/FileManagerIntents.java
@@ -126,4 +126,7 @@ public final class FileManagerIntents {
 	public static final String EXTRA_FILENAME = "org.openintents.extra.FILENAME";
 
     public static final String EXTRA_FROM_OI_FILEMANAGER = "org.openintents.extra.FROM_OI_FILEMANAGER";
+
+	private FileManagerIntents() {
+	}
 }

--- a/FileManagerDemo/src/org/openintents/intents/FileManagerIntents.java
+++ b/FileManagerDemo/src/org/openintents/intents/FileManagerIntents.java
@@ -63,4 +63,6 @@ public final class FileManagerIntents {
 	 */
 	public static final String EXTRA_BUTTON_TEXT = "org.openintents.extra.BUTTON_TEXT";
 
+	private FileManagerIntents() {
+	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed