### PR TITLE
use FileProvider for opening files

### DIFF
--- a/FileManager/AndroidManifest.xml
+++ b/FileManager/AndroidManifest.xml
@@ -179,6 +179,15 @@
             android:exported="true"
             android:grantUriPermissions="true">
         </provider>
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="org.openintents.filemanager.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
 
         <!-- Activities from OI Distribution Library -->
         <activity

--- a/FileManager/res/xml/file_paths.xml
+++ b/FileManager/res/xml/file_paths.xml
@@ -1,0 +1,3 @@
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external" path="" />
+</paths>

--- a/FileManager/src/org/openintents/filemanager/util/FileUtils.java
+++ b/FileManager/src/org/openintents/filemanager/util/FileUtils.java
@@ -33,8 +33,10 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.MediaStore.Audio;
 import android.provider.MediaStore.Video;
+import android.support.v4.content.FileProvider;
 import android.text.format.DateFormat;
 import android.text.format.Formatter;
 import android.util.Log;
@@ -323,7 +325,13 @@ public class FileUtils {
 	public static void openFile(FileHolder fileholder, Context c) {
 		Intent intent = new Intent(android.content.Intent.ACTION_VIEW);
 
-		Uri data = FileUtils.getUri(fileholder.getFile());
+		Uri data;
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+			intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+			data = FileProvider.getUriForFile(c, "org.openintents.filemanager.fileprovider", fileholder.getFile());
+		} else {
+			data = FileUtils.getUri(fileholder.getFile());
+		}
 		String type = fileholder.getMimeType();
 		
 		if ("*/*".equals(type)){


### PR DESCRIPTION
When targeting Android SDKs version N and higher, a `FileUriExposedException` is thrown
when exposing file:// URIs to open files.

This change makes use of the new content:// URIs and a FileProvider for
opening files on external storage.

Updates #86