### PR TITLE
Fixed typo in intents to open dir for #87: singular instead of plural…

### DIFF
--- a/FileManager/AndroidManifest.xml
+++ b/FileManager/AndroidManifest.xml
@@ -99,12 +99,12 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
-                <data android:mimeType="vnd.android.documents/directory"/>
+                <data android:mimeType="vnd.android.document/directory"/>
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
-                <data android:mimeType="resources/folder"/>
+                <data android:mimeType="resource/folder"/>
             </intent-filter>
 
             <meta-data


### PR DESCRIPTION
… mime type

 MIME_TYPE_DIR = "vnd.android.document/directory"; (instead of ...documents/directory) 

see https://developer.android.com/reference/android/provider/DocumentsContract.Document.html#MIME_TYPE_DIR

resource/folder (instead of resources/folder) which is used by other filemanager apps.

Can you also update the descripton in http://www.openintents.org/action/android-intent-action-view/file-directory?