### PR TITLE
Add some null safety & Add MediaScan on file deletion

### DIFF
--- a/FileManager/src/org/openintents/filemanager/search/SearchResultsProvider.java
+++ b/FileManager/src/org/openintents/filemanager/search/SearchResultsProvider.java
@@ -11,6 +11,8 @@ import android.database.sqlite.SQLiteOpenHelper;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
+
 /**
  * Used by the standard search Service, in order to provide results asynchronously to the SearchableActivity.
  *
@@ -43,7 +45,7 @@ public class SearchResultsProvider extends ContentProvider {
     }
 
     @Override
-    public Cursor query(Uri uri, String[] projection, String selection,
+    public Cursor query(@NonNull Uri uri, String[] projection, String selection,
                         String[] selectionArgs, String sortOrder) {
         SQLiteQueryBuilder sqlBuilder = new SQLiteQueryBuilder();
         sqlBuilder.setTables(TABLE_NAME);
@@ -58,7 +60,7 @@ public class SearchResultsProvider extends ContentProvider {
     }
 
     @Override
-    public Uri insert(Uri uri, ContentValues values) {
+    public Uri insert(@NonNull Uri uri, ContentValues values) {
         long rowID = db.insert(TABLE_NAME, "", values);
         if (rowID > 0) {
             Uri _uri = ContentUris.withAppendedId(CONTENT_URI, rowID);
@@ -69,21 +71,21 @@ public class SearchResultsProvider extends ContentProvider {
     }
 
     @Override
-    public int update(Uri uri, ContentValues values, String selection,
+    public int update(@NonNull Uri uri, ContentValues values, String selection,
                       String[] selectionArgs) {
         // We only write, read and delete the db. Not implemented for now.
         return 0;
     }
 
     @Override
-    public int delete(Uri uri, String selection, String[] selectionArgs) {
+    public int delete(@NonNull Uri uri, String selection, String[] selectionArgs) {
         int count = db.delete(TABLE_NAME, selection, selectionArgs);
         getContext().getContentResolver().notifyChange(uri, null);
         return count;
     }
 
     @Override
-    public String getType(Uri uri) {
+    public String getType(@NonNull Uri uri) {
         return SEARCH_MIMETYPE;
     }
 

--- a/FileManager/src/org/openintents/filemanager/search/SearchSuggestionsProvider.java
+++ b/FileManager/src/org/openintents/filemanager/search/SearchSuggestionsProvider.java
@@ -1,6 +1,7 @@
 package org.openintents.filemanager.search;
 
 import android.app.SearchManager;
+import android.bluetooth.BluetoothClass;
 import android.content.ContentProvider;
 import android.content.ContentUris;
 import android.content.ContentValues;
@@ -11,6 +12,8 @@ import android.os.Environment;
 import android.provider.BaseColumns;
 
 import java.util.ArrayList;
+
+import androidx.annotation.NonNull;
 
 /**
  * Not that good, but it's a working implementation at least. We REALLY need asynchronous suggestion refreshing.
@@ -32,7 +35,7 @@ public class SearchSuggestionsProvider extends ContentProvider {
     /**
      * Always clears all suggestions. Parameters other than uri are ignored.
      */
-    public int delete(Uri uri, String selection, String[] selectionArgs) {
+    public int delete(@NonNull Uri uri, String selection, String[] selectionArgs) {
         int count = mSuggestions.size();
         mSuggestions.clear();
         getContext().getContentResolver().notifyChange(uri, null);
@@ -41,12 +44,13 @@ public class SearchSuggestionsProvider extends ContentProvider {
     }
 
     @Override
-    public String getType(Uri uri) {
+    public String getType(@NonNull Uri uri) {
         return SEARCH_SUGGEST_MIMETYPE;
     }
 
     @Override
-    public Uri insert(Uri uri, ContentValues values) {
+    @NonNull
+    public Uri insert(@NonNull Uri uri, ContentValues values) {
         long id = mSuggestions.size() + 1;
         values.put(BaseColumns._ID, id);
         mSuggestions.add(values);
@@ -69,7 +73,7 @@ public class SearchSuggestionsProvider extends ContentProvider {
     /**
      * NOT a cheap call. Actual search happens here.
      */
-    public Cursor query(Uri uri, String[] projection, String selection,
+    public Cursor query(@NonNull Uri uri, String[] projection, String selection,
                         String[] selectionArgs, String sortOrder) {
         searcher.setQuery(uri.getLastPathSegment().toLowerCase());
 
@@ -97,7 +101,7 @@ public class SearchSuggestionsProvider extends ContentProvider {
     /**
      * We don't care about updating. Unimplemented.
      */
-    public int update(Uri uri, ContentValues values, String selection,
+    public int update(@NonNull Uri uri, ContentValues values, String selection,
                       String[] selectionArgs) {
         return 0;
     }

--- a/FileManager/src/org/openintents/filemanager/search/SearchSuggestionsProvider.java
+++ b/FileManager/src/org/openintents/filemanager/search/SearchSuggestionsProvider.java
@@ -1,7 +1,6 @@
 package org.openintents.filemanager.search;
 
 import android.app.SearchManager;
-import android.bluetooth.BluetoothClass;
 import android.content.ContentProvider;
 import android.content.ContentUris;
 import android.content.ContentValues;

--- a/FileManager/src/org/openintents/filemanager/util/MediaScannerUtils.java
+++ b/FileManager/src/org/openintents/filemanager/util/MediaScannerUtils.java
@@ -2,6 +2,7 @@ package org.openintents.filemanager.util;
 
 import android.content.Context;
 import android.content.Intent;
+import android.media.MediaScannerConnection;
 import android.net.Uri;
 
 import org.openintents.filemanager.files.FileHolder;
@@ -45,7 +46,9 @@ public abstract class MediaScannerUtils {
     }
 
     public static void informFileDeleted(Context c, File f) {
-        // TODO implement
+        String[] file = new String[]{f.getPath()};
+
+        MediaScannerConnection.scanFile(c, file, null, null);
     }
 
     public static void informFilesDeleted(Context c, File[] files) {


### PR DESCRIPTION
The null safety patch is for the Uris, they never should be null. 

The MediaScan on file deletion is an old todo, referring to Issue #33 